### PR TITLE
Fix desktopRun main class configuration

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -16,6 +16,7 @@ plugins {
 }
 
 val localBuildNumber = 65535
+val desktopMainClass = "org.dots.game.MainKt"
 
 class BuildInfo {
     val majorVersion: Int = (project.findProperty(BuildInfo::majorVersion.name) as? String)?.toInt() ?: 1
@@ -186,7 +187,7 @@ dependencies {
 
 compose.desktop {
     application {
-        mainClass = "org.dots.game.MainKt"
+        mainClass = desktopMainClass
 
         nativeDistributions {
             targetFormats(TargetFormat.Msi, TargetFormat.Dmg, TargetFormat.Deb)
@@ -214,6 +215,14 @@ compose.desktop {
                 menuGroup = "Game"
             }
         }
+    }
+}
+
+// Keep the Kotlin MPP carrier run task aligned with Compose Desktop's `run` task.
+gradle.projectsEvaluated {
+    project.tasks.matching { it.name == "desktopRun" }.all {
+        val desktopRunTask = this as JavaExec
+        desktopRunTask.mainClass.set(desktopMainClass)
     }
 }
 


### PR DESCRIPTION
## Summary
- reuse a shared desktop main class constant in the desktop Compose configuration
- explicitly propagate that main class to the Kotlin Multiplatform `desktopRun` carrier task after project evaluation
- keep `:composeApp:desktopRun` aligned with the already working `:composeApp:run` task

## Root Cause
`compose.desktop { application { mainClass = ... } }` configures the Compose Desktop `run` task, but the Kotlin Multiplatform `desktopRun` task still ends up with an empty `mainClass` value. That makes Gradle fail before the desktop app starts with `No main class specified and classpath is not an executable jar`.

## Validation
- `./gradlew.bat :composeApp:desktopRun`

Fixes #110
